### PR TITLE
Add indenpendent LaTeX frontend type.

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -11,6 +11,12 @@ jobs:
         uses: peaceiris/actions-mdbook@v1
         with:
           mdbook-version: 'latest'
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v1
+      - name: Setup mdbook-graphviz
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: mdbook-graphviz
       - name: Build book
         run: make book
       - name: Deploy

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ example-$(1)-release: examples/$(1)/config.yaml plugins release
 	bins/target/release/ayaka-check $$< --auto
 example-$(1)-gui-release: examples/$(1)/config.yaml plugins release
 	bins/target/release/ayaka-gui $$<
-examples/$(1)/config.tex: examples/$(1)/config.yaml
+examples/$(1)/config.tex: examples/$(1)/config.yaml plugins
 	cd bins && $$(MAKE) run-latex FILE=$$(realpath $$<)
 
 endef

--- a/bins/ayaka-latex/src/main.rs
+++ b/bins/ayaka-latex/src/main.rs
@@ -76,7 +76,7 @@ async fn main() -> Result<()> {
                 for s in action.line {
                     output.write(s.as_str()).await?;
                 }
-                output.write("\n").await?;
+                output.write("\n\n").await?;
                 if !action.switches.is_empty() {
                     output
                         .environment("itemize", |output| async move {

--- a/bins/ayaka-latex/src/main.rs
+++ b/bins/ayaka-latex/src/main.rs
@@ -39,7 +39,16 @@ async fn main() -> Result<()> {
 
             ctx.init_new();
             ctx.set_locale(opts.locale.unwrap_or_else(Locale::current));
+
+            let mut current_para = None;
+
             while let Some(action) = ctx.next_run() {
+                if action.para_title != current_para {
+                    current_para = action.para_title.clone();
+                    output
+                        .command("section", [action.para_title.unwrap_or_default()])
+                        .await?;
+                }
                 if let Some(name) = &action.character {
                     output.command("paragraph", [name]).await?;
                 }

--- a/bins/ayaka-latex/src/main.rs
+++ b/bins/ayaka-latex/src/main.rs
@@ -21,13 +21,15 @@ async fn main() -> Result<()> {
     env_logger::Builder::from_default_env()
         .filter_module("wasmer", LevelFilter::Warn)
         .try_init()?;
-    let context = Context::open(&opts.input, FrontendType::Text);
+    let context = Context::open(&opts.input, FrontendType::Latex);
     let mut ctx = context.await?;
 
     let output = tokio::fs::File::create(&opts.output).await?;
     let mut output = LaTeXWriter::new(output);
     output.command("documentclass", ["ctexart"]).await?;
     output.command("usepackage", ["lua-ul"]).await?;
+    output.command("usepackage", ["luatexja-ruby"]).await?;
+    output.command("usepackage", ["verbatim"]).await?;
     output.command("title", [&ctx.game.title]).await?;
     output.command("author", [&ctx.game.author]).await?;
     output

--- a/bins/ayaka-latex/src/main.rs
+++ b/bins/ayaka-latex/src/main.rs
@@ -27,6 +27,7 @@ async fn main() -> Result<()> {
     let output = tokio::fs::File::create(&opts.output).await?;
     let mut output = LaTeXWriter::new(output);
     output.command("documentclass", ["ctexart"]).await?;
+    output.command("usepackage", ["graphicx"]).await?;
     output.command("usepackage", ["lua-ul"]).await?;
     output.command("usepackage", ["luatexja-ruby"]).await?;
     output.command("usepackage", ["verbatim"]).await?;
@@ -41,6 +42,7 @@ async fn main() -> Result<()> {
             ctx.set_locale(opts.locale.unwrap_or_else(Locale::current));
 
             let mut current_para = None;
+            let mut current_bg = None;
 
             while let Some(action) = ctx.next_run() {
                 if action.para_title != current_para {
@@ -48,6 +50,25 @@ async fn main() -> Result<()> {
                     output
                         .command("section", [action.para_title.unwrap_or_default()])
                         .await?;
+                }
+                let bg = action.props.get("bg");
+                if current_bg.as_ref() != bg {
+                    current_bg = bg.cloned();
+                    if let Some(bg) = &current_bg {
+                        output
+                            .environment_attr("figure", "!htbp", |output| async move {
+                                output.command0("centering").await?;
+                                output
+                                    .command_attr(
+                                        "includegraphics",
+                                        "width=1\\linewidth",
+                                        [bg.replace('\\', "/")],
+                                    )
+                                    .await?;
+                                Ok(output)
+                            })
+                            .await?;
+                    }
                 }
                 if let Some(name) = &action.character {
                     output.command("paragraph", [name]).await?;

--- a/bins/ayaka-latex/src/writer.rs
+++ b/bins/ayaka-latex/src/writer.rs
@@ -11,11 +11,51 @@ impl LaTeXWriter {
         Self { file, ident: 0 }
     }
 
-    pub async fn write(&mut self, text: impl AsRef<str>) -> Result<&mut Self> {
+    async fn write_spaces(&mut self) -> Result<&mut Self> {
         self.file
-            .write_all(" ".repeat(self.ident * 4).as_bytes())
+            .write_all(
+                &std::iter::repeat(b' ')
+                    .take(self.ident * 4)
+                    .collect::<Vec<_>>(),
+            )
             .await?;
+        Ok(self)
+    }
+
+    pub async fn write(&mut self, text: impl AsRef<str>) -> Result<&mut Self> {
+        self.write_spaces().await?;
         self.file.write_all(text.as_ref().as_bytes()).await?;
+        Ok(self)
+    }
+
+    async fn command_impl(
+        &mut self,
+        cmd: impl AsRef<str>,
+        pre_attr: Option<impl AsRef<str>>,
+        args: impl IntoIterator<Item = impl AsRef<str>>,
+        post_attr: Option<impl AsRef<str>>,
+    ) -> Result<&mut Self> {
+        self.write_spaces().await?;
+        self.file
+            .write_all(format!("\\{}", cmd.as_ref()).as_bytes())
+            .await?;
+        if let Some(attr) = pre_attr {
+            self.file
+                .write_all(format!("[{}]", attr.as_ref()).as_bytes())
+                .await?;
+        }
+        let args = args
+            .into_iter()
+            .map(|arg| format!("{{{}}}", arg.as_ref()))
+            .flat_map(|s| s.into_bytes())
+            .collect::<Vec<_>>();
+        self.file.write_all(&args).await?;
+        if let Some(attr) = post_attr {
+            self.file
+                .write_all(format!("[{}]", attr.as_ref()).as_bytes())
+                .await?;
+        }
+        self.file.write_all(&[b'\n']).await?;
         Ok(self)
     }
 
@@ -24,19 +64,35 @@ impl LaTeXWriter {
         cmd: impl AsRef<str>,
         args: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> Result<&mut Self> {
-        self.write(format!("\\{}{}\n", cmd.as_ref(), unsafe {
-            String::from_utf8_unchecked(
-                args.into_iter()
-                    .map(|arg| format!("{{{}}}", arg.as_ref()))
-                    .flat_map(|s| s.into_bytes())
-                    .collect::<Vec<_>>(),
-            )
-        }))
-        .await
+        self.command_impl(cmd, None::<&str>, args, None::<&str>)
+            .await
     }
 
     pub async fn command0(&mut self, cmd: impl AsRef<str>) -> Result<&mut Self> {
         self.command(cmd, &[] as &[&str]).await
+    }
+
+    pub async fn command_attr(
+        &mut self,
+        cmd: impl AsRef<str>,
+        attr: impl AsRef<str>,
+        args: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> Result<&mut Self> {
+        self.command_impl(cmd, Some(attr), args, None::<&str>).await
+    }
+
+    async fn environment_impl<'a, F: Future<Output = Result<&'a mut Self>>>(
+        &'a mut self,
+        env: impl AsRef<str>,
+        attr: Option<impl AsRef<str>>,
+        f: impl FnOnce(&'a mut Self) -> F,
+    ) -> Result<&'a mut Self> {
+        self.command_impl("begin", None::<&str>, [env.as_ref()], attr)
+            .await?;
+        self.ident += 1;
+        let this = f(self).await?;
+        this.ident -= 1;
+        this.command("end", [env]).await
     }
 
     pub async fn environment<'a, F: Future<Output = Result<&'a mut Self>>>(
@@ -44,10 +100,15 @@ impl LaTeXWriter {
         env: impl AsRef<str>,
         f: impl FnOnce(&'a mut Self) -> F,
     ) -> Result<&'a mut Self> {
-        self.command("begin", [env.as_ref()]).await?;
-        self.ident += 1;
-        let this = f(self).await?;
-        this.ident -= 1;
-        this.command("end", [env]).await
+        self.environment_impl(env, None::<&str>, f).await
+    }
+
+    pub async fn environment_attr<'a, F: Future<Output = Result<&'a mut Self>>>(
+        &'a mut self,
+        env: impl AsRef<str>,
+        attr: impl AsRef<str>,
+        f: impl FnOnce(&'a mut Self) -> F,
+    ) -> Result<&'a mut Self> {
+        self.environment_impl(env, Some(attr), f).await
     }
 }

--- a/book/book.toml
+++ b/book/book.toml
@@ -7,3 +7,6 @@ title = "Ayaka Book"
 
 [rust]
 edition = "2021"
+
+[preprocessor.graphviz]
+command = "mdbook-graphviz"

--- a/book/src/config/script.md
+++ b/book/src/config/script.md
@@ -1,5 +1,5 @@
 # Script
-The script we use is dynamic typed.
+Ayaka script is dynamic typed.
 The only supported types are unit `~`, boolean, integer, and string.
 ``` rust
 pub enum RawValue {

--- a/book/src/config/summary.md
+++ b/book/src/config/summary.md
@@ -1,9 +1,9 @@
 # Config
-Our config file is based on YAML. The structure is simple to author.
+Ayaka config is based on YAML. The structure is simple to author.
 
 The articles below uses `ayaka-check` to show the example,
 it may behave a little different in GUI.
-To run the example, you need to create a config file with full [structure](./structure.md), go to the `bins` folder and run
+To run the examples, you need to create a config file with full [structure](./structure.md), go to the `bins` folder and run
 ``` bash
 $ cargo run --package ayaka-check -- path/to/config.yaml --auto
 ```

--- a/book/src/plugin/summary.md
+++ b/book/src/plugin/summary.md
@@ -23,3 +23,23 @@ plugins:
     - bar
 ```
 You don't need to specify the extension.
+
+## The text processing workflow
+``` dot process
+digraph {
+  ori[label="Raw text"];
+  lines[label="Structural lines"];
+  exec[label="Run scripts"];
+  cmd[label="Custom commands"];
+  texts[label="Final texts"];
+  history[label="Record history"];
+  output[label="Output"];
+
+  ori -> lines [label="TextParser"];
+  lines -> exec [label="ProgramParser"];
+  exec -> cmd [label="text plugins"];
+  cmd -> texts [label="action plugins"];
+  texts -> history;
+  history -> output;
+}
+```

--- a/book/src/plugin/text_plugin.md
+++ b/book/src/plugin/text_plugin.md
@@ -33,6 +33,10 @@ Hello world!
 ## The process result
 The `TextProcessResult` object is some lines and properties to be added to the current action. `line` will be appended to the current position of the command, and `props` will be set and update.
 
+## Notes about `rt-format`
+`rt-format` is used to deal with script calculations and runtime formatting.
+Therefore, if you want to add braces to the text, you need to double them in the text plugins.
+
 ## Existing plugins
 | Plugin     | Description          |
 | ---------- | -------------------- |

--- a/plugins/basictex/src/lib.rs
+++ b/plugins/basictex/src/lib.rs
@@ -36,8 +36,9 @@ fn text_font(
             res.line.push_back_block("</font>");
         }
         FrontendType::Latex => {
-            res.line.push_back_block(format!("\\{} ", cmd));
-            res.line.push_back_chars(&args[0])
+            res.line.push_back_block(format!("\\{}{{{{", cmd));
+            res.line.push_back_chars(&args[0]);
+            res.line.push_back_block("}}");
         }
     }
     res

--- a/plugins/basictex/src/lib.rs
+++ b/plugins/basictex/src/lib.rs
@@ -13,12 +13,18 @@ fn par(args: Vec<String>, ctx: TextProcessContext) -> TextProcessResult {
     let mut res = TextProcessResult::default();
     match ctx.frontend {
         FrontendType::Text => res.line.push_back_chars("\n"),
-        FrontendType::Html => res.line.push_back_chars("<br />"),
+        FrontendType::Html => res.line.push_back_block("<br />"),
+        FrontendType::Latex => res.line.push_back_block("\\par "),
     }
     res
 }
 
-fn text_font(args: Vec<String>, ctx: TextProcessContext, fonts: &str) -> TextProcessResult {
+fn text_font(
+    cmd: &str,
+    args: Vec<String>,
+    ctx: TextProcessContext,
+    fonts: &str,
+) -> TextProcessResult {
     assert_eq!(args.len(), 1);
     let mut res = TextProcessResult::default();
     match ctx.frontend {
@@ -29,23 +35,27 @@ fn text_font(args: Vec<String>, ctx: TextProcessContext, fonts: &str) -> TextPro
             res.line.push_back_chars(&args[0]);
             res.line.push_back_block("</font>");
         }
+        FrontendType::Latex => {
+            res.line.push_back_block(format!("\\{} ", cmd));
+            res.line.push_back_chars(&args[0])
+        }
     }
     res
 }
 
 #[export]
 fn textrm(args: Vec<String>, ctx: TextProcessContext) -> TextProcessResult {
-    text_font(args, ctx, "Times New Roman")
+    text_font("textrm", args, ctx, "Times New Roman")
 }
 
 #[export]
 fn textsf(args: Vec<String>, ctx: TextProcessContext) -> TextProcessResult {
-    text_font(args, ctx, "Arial")
+    text_font("textsf", args, ctx, "Arial")
 }
 
 #[export]
 fn texttt(args: Vec<String>, ctx: TextProcessContext) -> TextProcessResult {
-    text_font(args, ctx, "Courier New")
+    text_font("texttt", args, ctx, "Courier New")
 }
 
 #[export]
@@ -64,6 +74,9 @@ fn ruby(args: Vec<String>, ctx: TextProcessContext) -> TextProcessResult {
             res.line.push_back_block("</rt><rp>）</rp>");
             res.line.push_back_block("</ruby>");
         }
+        FrontendType::Latex => res
+            .line
+            .push_back_block(format!("\\ruby{{{}}}{{{}}}", args[0], args[1])),
     }
     res
 }

--- a/plugins/basictex/src/lib.rs
+++ b/plugins/basictex/src/lib.rs
@@ -76,7 +76,7 @@ fn ruby(args: Vec<String>, ctx: TextProcessContext) -> TextProcessResult {
         }
         FrontendType::Latex => res
             .line
-            .push_back_block(format!("\\ruby{{{}}}{{{}}}", args[0], args[1])),
+            .push_back_block(format!("\\ruby{{{{{}}}}}{{{{{}}}}}", args[0], args[1])),
     }
     res
 }

--- a/plugins/markdown/src/lib.rs
+++ b/plugins/markdown/src/lib.rs
@@ -349,9 +349,9 @@ where
                     self.write_chars(text);
                 }
                 Code(text) => {
-                    self.write_block("\\begin{{verbatim}}");
+                    self.write_block("\\texttt{");
                     self.write_chars(text);
-                    self.write_block("\\end{{verbatim}}");
+                    self.write_block("}");
                 }
                 SoftBreak => {
                     self.write_chars("\n");

--- a/plugins/markdown/src/lib.rs
+++ b/plugins/markdown/src/lib.rs
@@ -349,9 +349,9 @@ where
                     self.write_chars(text);
                 }
                 Code(text) => {
-                    self.write_block("\\begin{verbatim}");
+                    self.write_block("\\begin{{verbatim}}");
                     self.write_chars(text);
-                    self.write_block("\\end{verbatim}");
+                    self.write_block("\\end{{verbatim}}");
                 }
                 SoftBreak => {
                     self.write_chars("\n");

--- a/plugins/markdown/src/lib.rs
+++ b/plugins/markdown/src/lib.rs
@@ -21,6 +21,7 @@ fn process_action(mut ctx: ActionProcessContext) -> Action {
     ctx.action.line = match ctx.frontend {
         FrontendType::Html => writer.run_html().into_lines(),
         FrontendType::Text => writer.run_text().into_lines(),
+        FrontendType::Latex => writer.run_latex().into_lines(),
     };
     ctx.action
 }
@@ -100,7 +101,7 @@ where
                     self.write_block("</code>");
                 }
                 Html(html) => {
-                    self.write_block(html.into_string());
+                    self.write_block(html);
                 }
                 SoftBreak => {
                     self.write_chars("\n");
@@ -339,6 +340,29 @@ where
                 TaskListMarker(false) => self.write_chars("[ ]"),
             }
         }
+    }
+
+    pub fn run_latex(mut self) -> Self {
+        while let Some(event) = self.iter.next() {
+            match event {
+                Text(text) => {
+                    self.write_chars(text);
+                }
+                Code(text) => {
+                    self.write_block("\\begin{verbatim}");
+                    self.write_chars(text);
+                    self.write_block("\\end{verbatim}");
+                }
+                SoftBreak => {
+                    self.write_chars("\n");
+                }
+                HardBreak | Rule => {
+                    self.write_block("\\par ");
+                }
+                _ => {}
+            }
+        }
+        self
     }
 
     pub fn into_lines(self) -> ActionLines {

--- a/utils/ayaka-bindings-types/src/lib.rs
+++ b/utils/ayaka-bindings-types/src/lib.rs
@@ -109,6 +109,8 @@ pub enum FrontendType {
     Text,
     /// The frontend renders HTML.
     Html,
+    /// The frontend renders LaTeX.
+    Latex,
 }
 
 /// The unit of one line in an action.


### PR DESCRIPTION
The plugin should be aware of the LaTeX frontend, instead of raw text frontend.

The brace should be doubled because we use `rt-format` when processing actions.

And add some more features to the LaTeX frontend.