### PR TITLE
Revert "Bump pixi.js from 6.5.8 to 7.0.0 in /bins/ayaka-gui"

### DIFF
--- a/bins/ayaka-gui/package.json
+++ b/bins/ayaka-gui/package.json
@@ -18,7 +18,7 @@
     "bootstrap-dark-5": "^1.1.3",
     "lodash": "^4.17.21",
     "pixi-live2d-display": "^0.4.0",
-    "pixi.js": "^7.0.0",
+    "pixi.js": "^6.5.4",
     "timers-promises": "^1.0.1",
     "vue": "^3.2.39",
     "vue-i18n": "^9.2.2",


### PR DESCRIPTION
Reverts Uni-Gal/Ayaka#22

pixi-live2d support pixi6 only.