### PR TITLE
fix(.github/dependabot.yml): change cargo check to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,17 +3,17 @@ updates:
 - package-ecosystem: cargo
   directory: "/utils"
   schedule:
-    interval: daily
+    interval: weekly
 
 - package-ecosystem: cargo
   directory: "/plugins"
   schedule:
-    interval: daily
+    interval: weekly
 
 - package-ecosystem: cargo
   directory: "/bins"
   schedule:
-    interval: daily
+    interval: weekly
 
 - package-ecosystem: npm
   directory: "/bins/ayaka-gui"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,4 +18,4 @@ updates:
 - package-ecosystem: npm
   directory: "/bins/ayaka-gui"
   schedule:
-    interval: daily
+    interval: weekly


### PR DESCRIPTION
Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval

Haven't modify npm check because frondend tech-stack dependency update frequently.