### PR TITLE
Decouple settings manager from runtime.

### DIFF
--- a/bins/Cargo.lock
+++ b/bins/Cargo.lock
@@ -397,6 +397,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-window-state",
+ "tryiterator",
  "trylog",
 ]
 
@@ -456,7 +457,6 @@ dependencies = [
  "ayaka-plugin-wasmtime",
  "ayaka-primitive",
  "cfg-if",
- "dirs",
  "fallback",
  "futures-util",
  "icu_locid",

--- a/bins/ayaka-gui/src-tauri/Cargo.toml
+++ b/bins/ayaka-gui/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ actix-web = "4"
 actix-files = "0.6"
 actix-cors = "0.6"
 trylog = "0.3"
+tryiterator = { git = "https://github.com/Pernosco/tryiterator.git" }
 
 [features]
 default = [ "custom-protocol" ]

--- a/bins/ayaka-gui/src-tauri/src/settings.rs
+++ b/bins/ayaka-gui/src-tauri/src/settings.rs
@@ -1,0 +1,84 @@
+use ayaka_runtime::{
+    anyhow::{self, Result},
+    settings::*,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use std::path::{Path, PathBuf};
+use tauri::PathResolver;
+use tryiterator::TryIteratorExt;
+
+#[derive(Default)]
+pub struct FileSettingsManager {
+    local_data_dir: PathBuf,
+    config_dir: PathBuf,
+}
+
+impl FileSettingsManager {
+    pub fn new(resolver: &PathResolver) -> Self {
+        Self {
+            local_data_dir: resolver.app_local_data_dir().unwrap(),
+            config_dir: resolver.app_config_dir().unwrap(),
+        }
+    }
+
+    fn records_path_root(&self, game: &str) -> PathBuf {
+        self.local_data_dir.join("save").join(game)
+    }
+}
+
+impl SettingsManager for FileSettingsManager {
+    fn load_file<T: DeserializeOwned>(&self, path: impl AsRef<Path>) -> Result<T> {
+        let buffer = std::fs::read(path)?;
+        Ok(serde_json::from_slice(&buffer)?)
+    }
+
+    fn save_file<T: Serialize>(
+        &self,
+        path: impl AsRef<Path>,
+        data: &T,
+        pretty: bool,
+    ) -> Result<()> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let buffer = if pretty {
+            serde_json::to_vec_pretty(data)
+        } else {
+            serde_json::to_vec(data)
+        }?;
+        std::fs::write(path, buffer)?;
+        Ok(())
+    }
+
+    fn settings_path(&self) -> Result<PathBuf> {
+        Ok(self.config_dir.join("settings.json"))
+    }
+
+    fn global_record_path(&self, game: &str) -> Result<PathBuf> {
+        Ok(self.records_path_root(game).join("global.json"))
+    }
+
+    type RecordsPathIter = impl Iterator<Item = Result<PathBuf>>;
+
+    fn records_path(&self, game: &str) -> Result<Self::RecordsPathIter> {
+        let ctx_path = self.records_path_root(game);
+        Ok(std::fs::read_dir(ctx_path)?
+            .map_err(anyhow::Error::from)
+            .try_filter_map(|entry| {
+                let p = entry.path();
+                if p.is_file() && p.file_name().unwrap_or_default() != "global.json" {
+                    Ok(Some(p))
+                } else {
+                    Ok(None)
+                }
+            }))
+    }
+
+    fn record_path(&self, game: &str, i: usize) -> Result<PathBuf> {
+        Ok(self
+            .records_path_root(game)
+            .join(i.to_string())
+            .with_extension("json"))
+    }
+}

--- a/utils/ayaka-runtime/Cargo.toml
+++ b/utils/ayaka-runtime/Cargo.toml
@@ -18,7 +18,6 @@ anyhow = { workspace = true }
 stream-future = "0.3"
 futures-util = "0.3"
 tryiterator = { git = "https://github.com/Pernosco/tryiterator.git" }
-dirs = "4.0"
 log = { workspace = true }
 trylog = { workspace = true }
 cfg-if = "1.0"

--- a/utils/ayaka-runtime/src/context.rs
+++ b/utils/ayaka-runtime/src/context.rs
@@ -1,5 +1,6 @@
 use crate::{
     plugin::{LoadStatus, Runtime},
+    settings::*,
     *,
 };
 use anyhow::{anyhow, bail, Result};

--- a/utils/ayaka-runtime/src/lib.rs
+++ b/utils/ayaka-runtime/src/lib.rs
@@ -13,7 +13,7 @@ mod config;
 mod context;
 mod locale;
 pub mod plugin;
-mod settings;
+pub mod settings;
 
 #[doc(no_inline)]
 pub use anyhow;
@@ -29,7 +29,6 @@ pub use futures_util::{pin_mut, StreamExt, TryStreamExt};
 pub use locale::*;
 #[doc(no_inline)]
 pub use log;
-pub use settings::*;
 
 /// Get the version of Ayaka runtime.
 /// This version string is exacted from `CARGO_PKG_VERSION`.


### PR DESCRIPTION
The settings manager should be implemented by the frontend. This is the initial work for #4 .

We also remove `dirs` dependency from the runtime. Now the `tauri::PathResolver` handles all paths.