### PR TITLE
Make Ayaka script parser intrinsic

### DIFF
--- a/bins/Cargo.lock
+++ b/bins/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +259,7 @@ dependencies = [
  "ayaka-plugin-nop",
  "ayaka-plugin-wasmi",
  "ayaka-primitive",
+ "ayaka-script",
  "cfg-if",
  "fallback",
  "futures-util",
@@ -265,6 +275,18 @@ dependencies = [
  "trylog",
  "vfs",
  "vfs-tar",
+]
+
+[[package]]
+name = "ayaka-script"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ayaka-primitive",
+ "lalrpop",
+ "lalrpop-util",
+ "serde",
+ "trylog",
 ]
 
 [[package]]
@@ -287,6 +309,21 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -666,6 +703,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +889,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,10 +970,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
 
 [[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
 name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "ena"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1006,6 +1070,12 @@ dependencies = [
  "redox_syscall",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1765,6 +1835,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,6 +1928,38 @@ dependencies = [
  "html5ever",
  "matches",
  "selectors",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b30455341b0e18f276fa64540aff54deafb54c589de6aca68659c63dd2d5d823"
+dependencies = [
+ "ascii-canvas",
+ "atty",
+ "bit-set",
+ "diff",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf796c978e9b4d983414f4caedc9273aa33ee214c5b887bd55fde84c85d2dc4"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -2312,6 +2423,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,6 +2529,12 @@ checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "pin-project"
@@ -3495,6 +3622,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3570,6 +3708,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
 dependencies = [
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/plugins/Cargo.lock
+++ b/plugins/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,26 +16,6 @@ name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
-
-[[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -121,11 +92,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ayaka-primitive",
- "lalrpop",
- "lalrpop-util",
- "log",
  "serde",
- "trylog",
 ]
 
 [[package]]
@@ -147,21 +114,6 @@ version = "0.1.0"
 dependencies = [
  "ayaka-bindings",
 ]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -221,12 +173,6 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "cxx"
@@ -308,48 +254,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
-name = "either"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
-
-[[package]]
-name = "ena"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "fallback"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,12 +274,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,30 +289,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hex"
@@ -464,15 +342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,38 +354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "lalrpop"
-version = "0.19.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30455341b0e18f276fa64540aff54deafb54c589de6aca68659c63dd2d5d823"
-dependencies = [
- "ascii-canvas",
- "atty",
- "bit-set",
- "diff",
- "ena",
- "itertools",
- "lalrpop-util",
- "petgraph",
- "pico-args",
- "regex",
- "regex-syntax",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.19.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf796c978e9b4d983414f4caedc9273aa33ee214c5b887bd55fde84c85d2dc4"
-dependencies = [
- "regex",
 ]
 
 [[package]]
@@ -539,16 +376,6 @@ name = "live2d"
 version = "0.1.0"
 dependencies = [
  "ayaka-bindings",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
-dependencies = [
- "autocfg",
- "scopeguard",
 ]
 
 [[package]]
@@ -587,12 +414,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nom"
@@ -639,64 +460,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
-
-[[package]]
-name = "petgraph"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "pico-args"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro-crate"
@@ -746,43 +513,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "thiserror",
-]
-
-[[package]]
-name = "regex"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
 name = "rmp"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,22 +535,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
-
-[[package]]
 name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
@@ -888,31 +606,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
-
-[[package]]
-name = "smallvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
-
-[[package]]
-name = "string_cache"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
-dependencies = [
- "new_debug_unreachable",
- "once_cell",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
-]
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,43 +623,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -994,15 +656,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
 dependencies = [
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -1053,12 +706,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,12 +716,6 @@ name = "vfs"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded573c92d7b32013bdab82676be59f56106895e837504568f32804980ec7868"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1160,69 +801,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -23,6 +23,7 @@ ayaka-plugin-nop = { path = "ayaka-plugin-nop" }
 ayaka-plugin-wasmer = { path = "ayaka-plugin-wasmer" }
 ayaka-plugin-wasmtime = { path = "ayaka-plugin-wasmtime" }
 ayaka-plugin-wasmi = { path = "ayaka-plugin-wasmi" }
+ayaka-script = { path = "ayaka-script" }
 ayaka-runtime = { path = "ayaka-runtime" }
 
 anyhow = "1.0"

--- a/utils/ayaka-runtime/Cargo.toml
+++ b/utils/ayaka-runtime/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 ayaka-primitive = { workspace = true }
 ayaka-bindings-types = { workspace = true }
 ayaka-plugin = { workspace = true }
+ayaka-script = { workspace = true, features = ["parser"] }
 fallback = { workspace = true }
 language-matcher = "0.1"
 icu_locid = { version = "1.0.0", features = ["std"] }

--- a/utils/ayaka-runtime/src/plugin.rs
+++ b/utils/ayaka-runtime/src/plugin.rs
@@ -4,6 +4,7 @@ mod fs_interop;
 mod log_interop;
 mod plugin_interop;
 mod rand_interop;
+mod script_interop;
 
 #[cfg(test)]
 mod test;
@@ -136,6 +137,7 @@ impl<M: RawModule + Send + Sync + 'static> Runtime<M> {
         plugin_interop::register(&mut store, handle.clone())?;
         fs_interop::register(&mut store, root_path)?;
         rand_interop::register(&mut store)?;
+        script_interop::register(&mut store)?;
         let mut runtime = Self::new();
 
         let total_len = paths.len();

--- a/utils/ayaka-runtime/src/plugin/script_interop.rs
+++ b/utils/ayaka-runtime/src/plugin/script_interop.rs
@@ -1,0 +1,13 @@
+use anyhow::Result;
+use ayaka_plugin::{Linker, RawModule};
+use ayaka_script::Program;
+use std::collections::HashMap;
+
+pub fn register<M: RawModule>(store: &mut impl Linker<M>) -> Result<()> {
+    let parse_func = store.wrap(|(program,): (String,)| program.parse::<Program>());
+    store.import(
+        "script",
+        HashMap::from([("__parse".to_string(), parse_func)]),
+    )?;
+    Ok(())
+}

--- a/utils/ayaka-script/Cargo.toml
+++ b/utils/ayaka-script/Cargo.toml
@@ -7,9 +7,12 @@ edition = "2021"
 ayaka-primitive = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-log = { workspace = true }
-trylog = { workspace = true }
-lalrpop-util = { version = "0.19", features = ["lexer"] }
+trylog = { workspace = true, optional = true }
+lalrpop-util = { version = "0.19", features = ["lexer"], optional = true }
 
 [build-dependencies]
-lalrpop = "0.19"
+lalrpop = { version = "0.19", optional = true }
+
+[features]
+default = []
+parser = ["lalrpop-util", "lalrpop", "trylog"]

--- a/utils/ayaka-script/build.rs
+++ b/utils/ayaka-script/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    #[cfg(feature = "parser")]
     lalrpop::process_root().unwrap();
 }

--- a/utils/ayaka-script/src/lib.rs
+++ b/utils/ayaka-script/src/lib.rs
@@ -6,21 +6,18 @@
 #[doc(no_inline)]
 pub use ayaka_primitive::{RawValue, ValueType};
 
-use lalrpop_util::lalrpop_mod;
-use serde::Deserialize;
-use std::str::FromStr;
+use serde::{Deserialize, Serialize};
 
 /// A full script, a collection of expressions.
 ///
 /// The last expression is the final value of the script.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
-#[serde(try_from = "String")]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Program(pub Vec<Expr>);
 
 /// An expression.
 ///
 /// Two expressions should be splited with `;`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Expr {
     /// A reference to a variable.
     Ref(Ref),
@@ -35,7 +32,7 @@ pub enum Expr {
 }
 
 /// Unary operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum UnaryOp {
     /// `+`
     Positive,
@@ -46,7 +43,7 @@ pub enum UnaryOp {
 }
 
 /// Binary operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BinaryOp {
     /// Value operations.
     Val(ValBinaryOp),
@@ -59,7 +56,7 @@ pub enum BinaryOp {
 }
 
 /// Value binary operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ValBinaryOp {
     /// `+`
     Add,
@@ -80,7 +77,7 @@ pub enum ValBinaryOp {
 }
 
 /// Logical operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LogicBinaryOp {
     /// `&&`
     And,
@@ -101,7 +98,7 @@ pub enum LogicBinaryOp {
 }
 
 /// Reference of a variable.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Ref {
     /// A local variable.
     /// It is only accessible in current program.
@@ -112,6 +109,10 @@ pub enum Ref {
     Ctx(String),
 }
 
+#[cfg(feature = "parser")]
+use lalrpop_util::lalrpop_mod;
+
+#[cfg(feature = "parser")]
 lalrpop_mod!(
     #[allow(missing_docs)]
     #[allow(dead_code)]
@@ -119,9 +120,11 @@ lalrpop_mod!(
     grammer
 );
 
+#[cfg(feature = "parser")]
 pub use grammer::{ConstParser, ExprParser, ProgramParser, RefParser};
 
-impl FromStr for Program {
+#[cfg(feature = "parser")]
+impl std::str::FromStr for Program {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -131,15 +134,7 @@ impl FromStr for Program {
     }
 }
 
-impl TryFrom<String> for Program {
-    type Error = anyhow::Error;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        value.parse()
-    }
-}
-
-#[cfg(test)]
+#[cfg(all(test, feature = "parser"))]
 mod test {
     use crate::*;
 

--- a/utils/ayaka-script/src/lib.rs
+++ b/utils/ayaka-script/src/lib.rs
@@ -3,6 +3,11 @@
 #![warn(missing_docs)]
 #![deny(unsafe_code)]
 
+#[cfg(feature = "parser")]
+mod parser;
+#[cfg(feature = "parser")]
+pub use parser::*;
+
 #[doc(no_inline)]
 pub use ayaka_primitive::{RawValue, ValueType};
 
@@ -107,128 +112,4 @@ pub enum Ref {
     /// It is stored in the context.
     /// The variable name is prefixed with `$`.
     Ctx(String),
-}
-
-#[cfg(feature = "parser")]
-use lalrpop_util::lalrpop_mod;
-
-#[cfg(feature = "parser")]
-lalrpop_mod!(
-    #[allow(missing_docs)]
-    #[allow(dead_code)]
-    #[allow(clippy::all)]
-    grammer
-);
-
-#[cfg(feature = "parser")]
-pub use grammer::{ConstParser, ExprParser, ProgramParser, RefParser};
-
-#[cfg(feature = "parser")]
-impl std::str::FromStr for Program {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ProgramParser::new()
-            .parse(s)
-            .map_err(|e| anyhow::anyhow!("{}", e))
-    }
-}
-
-#[cfg(all(test, feature = "parser"))]
-mod test {
-    use crate::*;
-
-    fn var(s: &str) -> Expr {
-        Expr::Ref(Ref::Var(s.into()))
-    }
-
-    #[test]
-    fn program() {
-        assert_eq!(
-            ProgramParser::new()
-                .parse(
-                    "foo(a);
-                    foo.bar(a, b)"
-                )
-                .unwrap(),
-            Program(vec![
-                Expr::Call(String::default(), "foo".into(), vec![var("a")]),
-                Expr::Call("foo".into(), "bar".into(), vec![var("a"), var("b")])
-            ])
-        );
-    }
-
-    #[test]
-    fn expr() {
-        assert_eq!(ExprParser::new().parse("a").unwrap(), var("a"));
-        assert_eq!(
-            ExprParser::new().parse("!(a && b || c)").unwrap(),
-            Expr::Unary(
-                UnaryOp::Not,
-                Box::new(Expr::Binary(
-                    Box::new(Expr::Binary(
-                        Box::new(var("a")),
-                        BinaryOp::Logic(LogicBinaryOp::And),
-                        Box::new(var("b"))
-                    )),
-                    BinaryOp::Logic(LogicBinaryOp::Or),
-                    Box::new(var("c"))
-                ))
-            )
-        );
-        assert_eq!(
-            ExprParser::new().parse("foo(a)").unwrap(),
-            Expr::Call(String::default(), "foo".into(), vec![var("a")])
-        );
-        assert_eq!(
-            ExprParser::new().parse("foo.bar(a, b)").unwrap(),
-            Expr::Call("foo".into(), "bar".into(), vec![var("a"), var("b")])
-        );
-        assert_eq!(
-            ExprParser::new().parse("a + (b * (c & d))").unwrap(),
-            Expr::Binary(
-                Box::new(var("a")),
-                BinaryOp::Val(ValBinaryOp::Add),
-                Box::new(Expr::Binary(
-                    Box::new(var("b")),
-                    BinaryOp::Val(ValBinaryOp::Mul),
-                    Box::new(Expr::Binary(
-                        Box::new(var("c")),
-                        BinaryOp::Val(ValBinaryOp::And),
-                        Box::new(var("d"))
-                    ))
-                ))
-            )
-        );
-    }
-
-    #[test]
-    fn r#const() {
-        assert_eq!(ConstParser::new().parse("~").unwrap(), RawValue::Unit);
-
-        assert_eq!(
-            ConstParser::new().parse("true").unwrap(),
-            RawValue::Bool(true)
-        );
-        assert_eq!(
-            ConstParser::new().parse("false").unwrap(),
-            RawValue::Bool(false)
-        );
-
-        assert_eq!(
-            ConstParser::new().parse("114514").unwrap(),
-            RawValue::Num(114514.into())
-        );
-
-        assert_eq!(
-            ConstParser::new().parse("\"Hello world!\"").unwrap(),
-            RawValue::Str("Hello world!".into())
-        );
-    }
-
-    #[test]
-    fn r#ref() {
-        assert_eq!(RefParser::new().parse("a").unwrap(), Ref::Var("a".into()));
-        assert_eq!(RefParser::new().parse("$a").unwrap(), Ref::Ctx("a".into()));
-    }
 }

--- a/utils/ayaka-script/src/parser.rs
+++ b/utils/ayaka-script/src/parser.rs
@@ -1,0 +1,120 @@
+use crate::*;
+use lalrpop_util::lalrpop_mod;
+
+lalrpop_mod!(
+    #[allow(missing_docs)]
+    #[allow(dead_code)]
+    #[allow(clippy::all)]
+    grammer
+);
+
+pub use grammer::{ConstParser, ExprParser, ProgramParser, RefParser};
+
+impl std::str::FromStr for Program {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        ProgramParser::new()
+            .parse(s)
+            .map_err(|e| anyhow::anyhow!("{}", e))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::*;
+
+    fn var(s: &str) -> Expr {
+        Expr::Ref(Ref::Var(s.into()))
+    }
+
+    #[test]
+    fn program() {
+        assert_eq!(
+            ProgramParser::new()
+                .parse(
+                    "foo(a);
+                    foo.bar(a, b)"
+                )
+                .unwrap(),
+            Program(vec![
+                Expr::Call(String::default(), "foo".into(), vec![var("a")]),
+                Expr::Call("foo".into(), "bar".into(), vec![var("a"), var("b")])
+            ])
+        );
+    }
+
+    #[test]
+    fn expr() {
+        assert_eq!(ExprParser::new().parse("a").unwrap(), var("a"));
+        assert_eq!(
+            ExprParser::new().parse("!(a && b || c)").unwrap(),
+            Expr::Unary(
+                UnaryOp::Not,
+                Box::new(Expr::Binary(
+                    Box::new(Expr::Binary(
+                        Box::new(var("a")),
+                        BinaryOp::Logic(LogicBinaryOp::And),
+                        Box::new(var("b"))
+                    )),
+                    BinaryOp::Logic(LogicBinaryOp::Or),
+                    Box::new(var("c"))
+                ))
+            )
+        );
+        assert_eq!(
+            ExprParser::new().parse("foo(a)").unwrap(),
+            Expr::Call(String::default(), "foo".into(), vec![var("a")])
+        );
+        assert_eq!(
+            ExprParser::new().parse("foo.bar(a, b)").unwrap(),
+            Expr::Call("foo".into(), "bar".into(), vec![var("a"), var("b")])
+        );
+        assert_eq!(
+            ExprParser::new().parse("a + (b * (c & d))").unwrap(),
+            Expr::Binary(
+                Box::new(var("a")),
+                BinaryOp::Val(ValBinaryOp::Add),
+                Box::new(Expr::Binary(
+                    Box::new(var("b")),
+                    BinaryOp::Val(ValBinaryOp::Mul),
+                    Box::new(Expr::Binary(
+                        Box::new(var("c")),
+                        BinaryOp::Val(ValBinaryOp::And),
+                        Box::new(var("d"))
+                    ))
+                ))
+            )
+        );
+    }
+
+    #[test]
+    fn r#const() {
+        assert_eq!(ConstParser::new().parse("~").unwrap(), RawValue::Unit);
+
+        assert_eq!(
+            ConstParser::new().parse("true").unwrap(),
+            RawValue::Bool(true)
+        );
+        assert_eq!(
+            ConstParser::new().parse("false").unwrap(),
+            RawValue::Bool(false)
+        );
+
+        assert_eq!(
+            ConstParser::new().parse("114514").unwrap(),
+            RawValue::Num(114514.into())
+        );
+
+        assert_eq!(
+            ConstParser::new().parse("\"Hello world!\"").unwrap(),
+            RawValue::Str("Hello world!".into())
+        );
+    }
+
+    #[test]
+    fn r#ref() {
+        assert_eq!(RefParser::new().parse("a").unwrap(), Ref::Var("a".into()));
+        assert_eq!(RefParser::new().parse("$a").unwrap(), Ref::Ctx("a".into()));
+    }
+}


### PR DESCRIPTION
We would like it to make `ayacript` plugin faster. It is very fast with wasmtime and wasmer, but not so fast with wasmi, which is our default WASM engine.